### PR TITLE
Add grouping feature by uid attribute

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,11 @@
             <artifactId>commons-csv</artifactId>
             <version>${commons.csv.version}</version>
         </dependency>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.10.1</version>
+        </dependency>
 
         <!-- TEST DEPENDENCIES -->
 

--- a/src/main/java/com/evolveum/polygon/connector/csv/CsvConfiguration.java
+++ b/src/main/java/com/evolveum/polygon/connector/csv/CsvConfiguration.java
@@ -197,6 +197,17 @@ public class CsvConfiguration extends AbstractConfiguration {
         return config.isAuxiliary();
     }
 
+    @ConfigurationProperty(
+            displayMessageKey = "UI_CSV_GROUP_BY_ENABLED",
+            helpMessageKey = "UI_CSV_GROUP_BY_ENABLED_HELP")
+    public boolean isGroupByEnabled() {
+        return config.isGroupByEnabled();
+    }
+
+    public void setGroupByEnabled(boolean groupByEnabled) {
+        config.setGroupByEnabled(groupByEnabled);
+    }
+
     public void setContainer(boolean container) {
         config.setContainer(container);
     }

--- a/src/main/java/com/evolveum/polygon/connector/csv/ObjectClassHandlerConfiguration.java
+++ b/src/main/java/com/evolveum/polygon/connector/csv/ObjectClassHandlerConfiguration.java
@@ -55,6 +55,8 @@ public class ObjectClassHandlerConfiguration {
     private boolean container = false;
     private boolean auxiliary = false;
 
+    private boolean groupByEnabled = false;
+
     public ObjectClassHandlerConfiguration() {
         this(ObjectClass.ACCOUNT, null);
     }
@@ -92,6 +94,8 @@ public class ObjectClassHandlerConfiguration {
 
         setContainer(Util.getSafeValue(values, "container", false, Boolean.class));
         setAuxiliary(Util.getSafeValue(values, "auxiliary", false, Boolean.class));
+
+        setGroupByEnabled(Util.getSafeValue(values, "groupByEnabled", false, Boolean.class));
     }
 
     public void recompute() {
@@ -102,6 +106,14 @@ public class ObjectClassHandlerConfiguration {
         if (StringUtil.isEmpty(nameAttribute)) {
             nameAttribute = uniqueAttribute;
         }
+    }
+
+    public boolean isGroupByEnabled() {
+        return groupByEnabled;
+    }
+
+    public void setGroupByEnabled(boolean groupByEnabled) {
+        this.groupByEnabled = groupByEnabled;
     }
 
     public boolean isContainer() {

--- a/src/main/resources/com/evolveum/polygon/connector/csv/Messages.properties
+++ b/src/main/resources/com/evolveum/polygon/connector/csv/Messages.properties
@@ -51,3 +51,5 @@ UI_CONTAINER=Container
 UI_CONTAINER_HELP=Should this object class be marked as container? Default is false.
 UI_AUXILIARY=Auxiliary
 UI_AUXILIARY_HELP=Should this object class be marked as auxiliary? Default is false.
+UI_CSV_GROUP_BY_ENABLED=Group by enabled
+UI_CSV_GROUP_BY_ENABLED_HELP=Enable group by unique attribute when reading csv (except for sync operation). The aggregated data is mapped to the "__RAW_JSON__" attribute with string type.

--- a/src/test/java/com/evolveum/polygon/connector/csv/SearchOpTest.java
+++ b/src/test/java/com/evolveum/polygon/connector/csv/SearchOpTest.java
@@ -3,6 +3,8 @@ package com.evolveum.polygon.connector.csv;
 import com.evolveum.polygon.connector.csv.util.ListResultHandler;
 import org.identityconnectors.framework.api.ConnectorFacade;
 import org.identityconnectors.framework.common.exceptions.ConnectorException;
+import org.identityconnectors.framework.common.objects.Attribute;
+import org.identityconnectors.framework.common.objects.AttributeUtil;
 import org.identityconnectors.framework.common.objects.ConnectorObject;
 import org.identityconnectors.framework.common.objects.ObjectClass;
 import org.identityconnectors.framework.common.objects.Uid;
@@ -11,6 +13,7 @@ import org.testng.AssertJUnit;
 import org.testng.annotations.Test;
 
 import java.io.File;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -76,5 +79,103 @@ public class SearchOpTest extends BaseTest {
 
         ConnectorFacade connector = setupConnector("/search-wrong-column-count-row.csv", config);
         connector.search(ObjectClass.ACCOUNT, null, new ListResultHandler(), null);
+    }
+
+    @Test
+    public void findOneWithGroupByEnabled() throws Exception {
+        CsvConfiguration config = new CsvConfiguration();
+        config.setFilePath(new File(CSV_FILE_PATH));
+        config.setUniqueAttribute("id");
+        config.setMultivalueAttributes("tel");
+        config.setMultivalueDelimiter(",");
+        config.setGroupByEnabled(true);
+        ConnectorFacade connector = setupConnector("/search-grouping.csv", config);
+
+        ListResultHandler handler = new ListResultHandler();
+        EqualsFilter ef = new EqualsFilter(new Uid("1"));
+        connector.search(ObjectClass.ACCOUNT, ef, handler, null);
+
+        List<ConnectorObject> objects = handler.getObjects();
+
+        AssertJUnit.assertEquals(1, objects.size());
+        ConnectorObject connectorObject = objects.get(0);
+        Attribute id = connectorObject.getAttributeByName(Uid.NAME);
+        AssertJUnit.assertEquals("1", AttributeUtil.getStringValue(id));
+        Attribute dept = connectorObject.getAttributeByName("dept");
+        AssertJUnit.assertEquals("abc", AttributeUtil.getStringValue(dept));
+        Attribute title = connectorObject.getAttributeByName("title");
+        AssertJUnit.assertEquals("engineer", AttributeUtil.getStringValue(title));
+        Attribute tel = connectorObject.getAttributeByName("tel");
+        AssertJUnit.assertEquals(List.of("1111"), tel.getValue());
+        Attribute rawJson = connectorObject.getAttributeByName("__RAW_JSON__");
+        AssertJUnit.assertNotNull(rawJson);
+        String jsonValue = AttributeUtil.getStringValue(rawJson);
+        AssertJUnit.assertEquals("[{\"name\":\"john\",\"tel\":[\"1111\"],\"id\":\"1\",\"dept\":\"abc\",\"title\":\"engineer\"},{\"name\":\"john\",\"tel\":[\"1111\"],\"id\":\"1\",\"dept\":\"efg\",\"title\":\"manager\"}]", jsonValue);
+    }
+
+    @Test
+    public void findAllWithGroupByEnabled() throws Exception {
+        CsvConfiguration config = new CsvConfiguration();
+        config.setFilePath(new File(CSV_FILE_PATH));
+        config.setUniqueAttribute("id");
+        config.setMultivalueAttributes("tel");
+        config.setMultivalueDelimiter(",");
+        config.setGroupByEnabled(true);
+        ConnectorFacade connector = setupConnector("/search-grouping.csv", config);
+
+        ListResultHandler handler = new ListResultHandler();
+        connector.search(ObjectClass.ACCOUNT, null, handler, null);
+
+        List<ConnectorObject> objects = handler.getObjects();
+
+        AssertJUnit.assertEquals(3, objects.size());
+
+        ConnectorObject connectorObject = objects.get(0);
+        Attribute id = connectorObject.getAttributeByName(Uid.NAME);
+        AssertJUnit.assertEquals("1", AttributeUtil.getStringValue(id));
+        Attribute name = connectorObject.getAttributeByName("name");
+        AssertJUnit.assertEquals("john", AttributeUtil.getStringValue(name));
+        Attribute dept = connectorObject.getAttributeByName("dept");
+        AssertJUnit.assertEquals("abc", AttributeUtil.getStringValue(dept));
+        Attribute title = connectorObject.getAttributeByName("title");
+        AssertJUnit.assertEquals("engineer", AttributeUtil.getStringValue(title));
+        Attribute tel = connectorObject.getAttributeByName("tel");
+        AssertJUnit.assertEquals(List.of("1111"), tel.getValue());
+        Attribute rawJson = connectorObject.getAttributeByName("__RAW_JSON__");
+        AssertJUnit.assertNotNull(rawJson);
+        String jsonValue = AttributeUtil.getStringValue(rawJson);
+        AssertJUnit.assertEquals("[{\"name\":\"john\",\"tel\":[\"1111\"],\"id\":\"1\",\"dept\":\"abc\",\"title\":\"engineer\"},{\"name\":\"john\",\"tel\":[\"1111\"],\"id\":\"1\",\"dept\":\"efg\",\"title\":\"manager\"}]", jsonValue);
+
+        connectorObject = objects.get(1);
+        id = connectorObject.getAttributeByName(Uid.NAME);
+        AssertJUnit.assertEquals("2", AttributeUtil.getStringValue(id));
+        name = connectorObject.getAttributeByName("name");
+        AssertJUnit.assertEquals("jack", AttributeUtil.getStringValue(name));
+        dept = connectorObject.getAttributeByName("dept");
+        AssertJUnit.assertEquals("abc", AttributeUtil.getStringValue(dept));
+        title = connectorObject.getAttributeByName("title");
+        AssertJUnit.assertEquals("manager", AttributeUtil.getStringValue(title));
+        tel = connectorObject.getAttributeByName("tel");
+        AssertJUnit.assertEquals(List.of("1111", "2222"), tel.getValue());
+        rawJson = connectorObject.getAttributeByName("__RAW_JSON__");
+        AssertJUnit.assertNotNull(rawJson);
+        jsonValue = AttributeUtil.getStringValue(rawJson);
+        AssertJUnit.assertEquals("[{\"name\":\"jack\",\"tel\":[\"1111\",\"2222\"],\"id\":\"2\",\"dept\":\"abc\",\"title\":\"manager\"}]", jsonValue);
+
+        connectorObject = objects.get(2);
+        id = connectorObject.getAttributeByName(Uid.NAME);
+        AssertJUnit.assertEquals("3", AttributeUtil.getStringValue(id));
+        name = connectorObject.getAttributeByName("name");
+        AssertJUnit.assertEquals("bob", AttributeUtil.getStringValue(name));
+        dept = connectorObject.getAttributeByName("dept");
+        AssertJUnit.assertNull(dept);
+        title = connectorObject.getAttributeByName("title");
+        AssertJUnit.assertNull(title);
+        tel = connectorObject.getAttributeByName("tel");
+        AssertJUnit.assertNull(tel);
+        rawJson = connectorObject.getAttributeByName("__RAW_JSON__");
+        AssertJUnit.assertNotNull(rawJson);
+        jsonValue = AttributeUtil.getStringValue(rawJson);
+        AssertJUnit.assertEquals("[{\"name\":\"bob\",\"tel\":[],\"id\":\"3\",\"dept\":\"\",\"title\":\"\"}]", jsonValue);
     }
 }

--- a/src/test/resources/search-grouping.csv
+++ b/src/test/resources/search-grouping.csv
@@ -1,0 +1,5 @@
+id;name;dept;title;tel
+1;john;abc;engineer;1111
+1;john;efg;manager;1111
+2;jack;abc;manager;1111,2222
+3;bob;;;


### PR DESCRIPTION
I added `groupByEnabled` option, which uses the uid attribute for grouping. Enabling this option allows CSV records with multiple rows per account to be aggregated by uid attribute and read as JSON string.

## Motivation

In our experience with IDM projects, when importing data into the IDM system via CSV, we often deal with multiple rows per account. For example, the following csv:

```
id;name;dept;title
1;john;abc;engineer
1;john;efg;manager
2;jack;abc;manager
```

In the above example, the first row means that `john` belongs to the `abc` department as `engineer`, and the second row means that `john` belongs to the `efg` department as `manager`.

The current CSV connector cannot handle this kind of one-account, multiple rows data. Therefore, in this use case, we currently had to create custom BulkAction to read CSV files and update midPoint user data.
We would be happy if the CSV connector natively supports such use cases, so I have created this pull request.

## How does this option work?

When `groupByEnabled` is enabled, then the executeQuery method is called, it will perform grouping by the value of the Uid and map it as a JSON string to a special attribute, `__RAW_JSON__`. For example, in the CSV `john` example above, the following JSON string is mapped. Note that other attributes are mapped from the first row of the grouped rows.

```
[
  {
    "name": "john",
    "id": "1",
    "dept": "abc",
    "title": "engineer"
  },
  {
    "name": "john",
    "id": "1",
    "dept": "efg",
    "title": "manager"
  }
]
```

## Example inbound mapping on midPoint side

Here is an example of inbound mapping of a CSV resource definition that searches for OrgType by the value of the dept column in the CSV and assigns that organization. The value of the title column of the CSV is set to the `subtype` of the assignment to express which position in the organization is being assigned.

```
            <attribute>
                <c:ref>ri:__RAW_JSON__</c:ref>
                <inbound>
                    <expression>
                        <script>
                            <code>
                                import groovy.json.JsonSlurper
                                import com.evolveum.midpoint.xml.ns._public.common.common_3.*
                                
                                json = new JsonSlurper().parseText(input)
                                assignments = json.collect { [midpoint.searchObjectByName(OrgType.class, it.dept), it.title] }
                                    .findAll { it[0] != null }
                                    .collect {
                                        ref = new ObjectReferenceType()
                                        ref.setOid(it[0].oid)
                                        ref.setType(OrgType.COMPLEX_TYPE)

                                        assignment = new AssignmentType()
                                        assignment.setTargetRef(ref)
                                        assignment.subtype("dept")
                                        assignment.subtype(it[1])
                                        return assignment
                                    }
                                
                                log.info("created assignments: {}", assignments)
                                
                                return assignments
                            </code>
                        </script>
                    </expression>
                    <target>
                        <path>$focus/assignment</path>
                        <set>
                            <condition>
                                <script>
                                    <code>
                                        assignment?.subtype?.contains('dept')
                                    </code>
                                </script>
                            </condition>
                        </set>
                    </target>
                </inbound>
```

