### PR TITLE
allow escape sequences (like tab delimiters)

### DIFF
--- a/src/main/java/com/evolveum/polygon/connector/csv/util/Util.java
+++ b/src/main/java/com/evolveum/polygon/connector/csv/util/Util.java
@@ -226,6 +226,19 @@ public class Util {
             return null;
         }
 
+        if (value.length() == 2 && value.startsWith("\\")) {
+            // This is likely to be an escape sequence, like \t
+            // We'll take advantage of Properties to convert this to a character
+            Properties props = new Properties();
+            try {
+                props.load(new StringReader("key=" + value));
+            } catch (IOException ex) {
+                throw new ConfigurationException("Can't cast to character, reason: " + ex.getMessage(), ex);
+            }
+
+            value = props.getProperty("key");
+        }
+
         if (value.length() != 1) {
             throw new ConfigurationException("Can't cast to character, illegal string size: "
                     + value.length() + ", should be 1");

--- a/src/test/java/com/evolveum/polygon/connector/csv/ConfigurationTest.java
+++ b/src/test/java/com/evolveum/polygon/connector/csv/ConfigurationTest.java
@@ -49,4 +49,16 @@ public class ConfigurationTest extends BaseTest {
         ConnectorFacade connector = setupConnector("/create.csv", config);
         connector.test();
     }
+
+    @Test
+    public void testTabDelimiter() throws Exception {
+        CsvConfiguration config = new CsvConfiguration();
+        config.setUniqueAttribute("uid");
+        config.setFieldDelimiter("\\t");
+        config.setReadOnly(true);
+
+        ConnectorFacade connector = setupConnector("/create-tabs.tsv", config);
+        connector.test();
+
+    }
 }

--- a/src/test/resources/create-tabs.tsv
+++ b/src/test/resources/create-tabs.tsv
@@ -1,0 +1,2 @@
+firstName	uid	lastName	password
+john	123	doe	qwe123


### PR DESCRIPTION
We found that adding `\t` as a delimiter comes through to the connector as `\\t`, triggering an error. This updates the connector so that tabs and other escape sequences work. 