### PR TITLE
MID-10911 Fix CSV connector error handling for empty unique attribute

### DIFF
--- a/src/main/java/com/evolveum/polygon/connector/csv/ObjectClassHandler.java
+++ b/src/main/java/com/evolveum/polygon/connector/csv/ObjectClassHandler.java
@@ -946,6 +946,14 @@ public class ObjectClassHandler implements CreateOp, DeleteOp, TestOp, SearchOp<
         return reversed;
     }
 
+    private void validateRequiredAttributeValue(CSVRecord record, String value, String attributeName, String role) {
+        if (StringUtil.isBlank(value)) {
+            throw new InvalidAttributeValueException("CSV validation failed. Required " + role
+                    + " attribute '" + attributeName + "' is empty at record " + record.getRecordNumber()
+                    + ". Each record must contain a non-empty value for '" + attributeName + "'.");
+        }
+    }
+
     private ConnectorObject createConnectorObject(CSVRecord record) {
         ConnectorObjectBuilder builder = new ConnectorObjectBuilder();
 
@@ -961,16 +969,17 @@ public class ObjectClassHandler implements CreateOp, DeleteOp, TestOp, SearchOp<
             String name = header.get(i);
             String value = record.get(i);
 
-            if (StringUtil.isEmpty(value)) {
-                continue;
-            }
-
             if (name.equals(configuration.getUniqueAttribute())) {
+                validateRequiredAttributeValue(record, value, configuration.getUniqueAttribute(), "unique");
                 builder.setUid(value);
 
                 if (!isUniqueAndNameAttributeEqual()) {
                     continue;
                 }
+            }
+
+            if (StringUtil.isEmpty(value)) {
+                continue;
             }
 
             if (name.equals(configuration.getNameAttribute())) {

--- a/src/test/java/com/evolveum/polygon/connector/csv/SearchOpTest.java
+++ b/src/test/java/com/evolveum/polygon/connector/csv/SearchOpTest.java
@@ -3,6 +3,7 @@ package com.evolveum.polygon.connector.csv;
 import com.evolveum.polygon.connector.csv.util.ListResultHandler;
 import org.identityconnectors.framework.api.ConnectorFacade;
 import org.identityconnectors.framework.common.exceptions.ConnectorException;
+import org.identityconnectors.framework.common.exceptions.InvalidAttributeValueException;
 import org.identityconnectors.framework.common.objects.Attribute;
 import org.identityconnectors.framework.common.objects.ConnectorObject;
 import org.identityconnectors.framework.common.objects.ObjectClass;
@@ -28,6 +29,52 @@ public class SearchOpTest extends BaseTest {
 
         List<ConnectorObject> objects = handler.getObjects();
         AssertJUnit.assertEquals(2, objects.size());
+    }
+
+    @Test
+    public void emptyQuotedUniqueAttributeValue() throws Exception {
+        assertSearchFails(
+                "/search-empty-unique-quoted.csv"
+        );
+    }
+
+    @Test
+    public void emptyUnquotedUniqueAttributeValue() throws Exception {
+        assertSearchFails(
+                "/search-empty-unique-unquoted.csv"
+        );
+    }
+
+    @Test
+    public void blankUniqueAttributeValue() throws Exception {
+        assertSearchFails(
+                "/search-blank-unique.csv"
+        );
+    }
+
+    @Test
+    public void validRowsWithUniqueAttribute() throws Exception {
+        ConnectorFacade connector = setupConnector("/search-empnum-valid.csv", createEmpnumConfiguration());
+
+        ListResultHandler handler = new ListResultHandler();
+        connector.search(ObjectClass.ACCOUNT, null, handler, null);
+
+        List<ConnectorObject> objects = handler.getObjects();
+        AssertJUnit.assertEquals(2, objects.size());
+        AssertJUnit.assertEquals(new Uid("1001"), objects.get(0).getUid());
+        AssertJUnit.assertEquals(new Uid("1002"), objects.get(1).getUid());
+    }
+
+    @Test
+    public void noConfiguredNameAttributeUsesUniqueAttributeFallback() throws Exception {
+        ConnectorFacade connector = setupConnector("/search-empnum-valid.csv", createEmpnumConfiguration());
+
+        ListResultHandler handler = new ListResultHandler();
+        connector.search(ObjectClass.ACCOUNT, null, handler, null);
+
+        List<ConnectorObject> objects = handler.getObjects();
+        AssertJUnit.assertEquals(2, objects.size());
+        AssertJUnit.assertEquals("1001", objects.get(0).getName().getNameValue());
     }
 
     @Test
@@ -106,5 +153,27 @@ public class SearchOpTest extends BaseTest {
 
         AssertJUnit.assertTrue(organizations.contains("org1"));
         AssertJUnit.assertTrue(organizations.contains("org2"));
+    }
+
+    private CsvConfiguration createEmpnumConfiguration() {
+        CsvConfiguration config = new CsvConfiguration();
+        config.setFilePath(new File(CSV_FILE_PATH));
+        config.setFieldDelimiter(",");
+        config.setUniqueAttribute("empnum");
+        config.setPasswordAttribute(null);
+        return config;
+    }
+
+    private void assertSearchFails(String csvTemplate) throws Exception {
+        ConnectorFacade connector = setupConnector(csvTemplate, createEmpnumConfiguration());
+
+        try {
+            connector.search(ObjectClass.ACCOUNT, null, new ListResultHandler(), null);
+            AssertJUnit.fail("Expected " + InvalidAttributeValueException.class.getSimpleName());
+        } catch (Exception ex) {
+            AssertJUnit.assertEquals(InvalidAttributeValueException.class, ex.getClass());
+            AssertJUnit.assertEquals("CSV validation failed. Required unique attribute 'empnum' is empty at record 2. " +
+                    "Each record must contain a non-empty value for 'empnum'.", ex.getMessage());
+        }
     }
 }

--- a/src/test/resources/search-blank-unique.csv
+++ b/src/test/resources/search-blank-unique.csv
@@ -1,0 +1,2 @@
+empnum,firstname,surname
+"   ",John,Newman

--- a/src/test/resources/search-empnum-valid.csv
+++ b/src/test/resources/search-empnum-valid.csv
@@ -1,0 +1,3 @@
+empnum,firstname,surname
+1001,Geena,Green
+1002,John,Newman

--- a/src/test/resources/search-empty-unique-quoted.csv
+++ b/src/test/resources/search-empty-unique-quoted.csv
@@ -1,0 +1,2 @@
+"empnum","firstname","surname"
+"","John","Newman"

--- a/src/test/resources/search-empty-unique-unquoted.csv
+++ b/src/test/resources/search-empty-unique-unquoted.csv
@@ -1,0 +1,2 @@
+empnum,firstname,surname
+,John,Newman


### PR DESCRIPTION
## Summary

Fixes CSV connector error handling when the configured unique attribute column contains an empty value.

Previously, empty values were skipped before the connector checked whether the field was the configured unique attribute. If a CSV record had an empty value in that column, the connector attempted to build a ConnId object without a `Uid`, which later failed with a generic error:

```text
The Attribute set must contain a 'Uid'.
```

This resulted in poor diagnostics in midPoint, typically shown as only `Fatal error`.

## Changes

- Validate the configured unique attribute value before empty fields are skipped.
- Reject blank unique attribute values, including:
  - quoted empty value: `""`
  - unquoted empty value
  - whitespace-only value
- Throw `InvalidAttributeValueException` with an actionable message containing:
  - the configured unique attribute name,
  - the CSV record number,
  - a remediation hint.
- Add regression tests for empty, blank, and valid unique attribute values.

## Example error after fix

```text
CSV validation failed. Required unique attribute 'empnum' is empty at record 2. Each record must contain a non-empty value for 'empnum'.
```

## Testing

Added search operation tests for:

- quoted empty unique attribute value,
- unquoted empty unique attribute value,
- whitespace-only unique attribute value,
- valid rows with non-empty unique values,
- fallback behavior when no name attribute is configured.